### PR TITLE
Allow unescaped / in regex (with warning)

### DIFF
--- a/priv/www/css/virex.css
+++ b/priv/www/css/virex.css
@@ -204,3 +204,7 @@ button {
 #update_regex {
   margin-top: 27px;
 }
+
+#slash_warning {
+  color: rgba(255, 128, 128, 1)
+}

--- a/priv/www/index.html
+++ b/priv/www/index.html
@@ -16,6 +16,7 @@
         <span class="slash prefix_1 pattern_offset">/</span>
         <input type="text" id="regex" placeholder="Your regular expression" data-behavior="submit-regex-query" maxlength="80">
         <span class="slash">/g</span>
+        <div class="prefix_1 pattern_offset" id="slash_warning"><br /></div>
       </div>
       <div class="clear vertical-spacer"><br /></div>
       <div class="grid_6">

--- a/priv/www/js/virex.js
+++ b/priv/www/js/virex.js
@@ -17,4 +17,13 @@ $(document).ready(function() {
         });
     }
   });
+  $("#regex").keyup( function() {
+    regex = $('#regex').val();
+    warning_div = $('#slash_warning')
+    if (/(^|[^\\])(\\{2})*\//.test(regex)) {
+      warning_div.html("&nbsp;&nbsp;WARNING: This regex contains an unescaped /");
+    } else {
+      warning_div.html("<br />");
+    }
+  });
 });

--- a/src/vim.erl
+++ b/src/vim.erl
@@ -40,8 +40,9 @@ create_test_file(TestString) ->
 
 
 substitution_command(Filename, Pattern) ->
+  Delimiter = [1],
   Replacement = replacement_command(Pattern),
-  Substitute = "%s/" ++ Pattern ++ "/" ++  Replacement ++ "/g",
+  Substitute = "%s" ++ Delimiter ++ Pattern ++ Delimiter ++ Replacement ++ Delimiter ++ "g",
   ["-X", Filename, "-c", Substitute, "-c", ?HTMLFORMAT, "-c", "x"].
 
 
@@ -64,7 +65,7 @@ secure_pattern(Pattern) ->
 safe(Pattern) when erlang:length(Pattern) > 80 ->
   false;
 safe(Pattern) ->
-  DangerousRegex = "\{-?[0-9]{3,}|[0-9]{3,}\\\\?\}|([^\\\\]|^)(\\\\\\\\)*/",
+  DangerousRegex = "\{-?[0-9]{3,}|[0-9]{3,}\\\\?\}",
   re:run(Pattern, DangerousRegex) =:= nomatch.
 
 

--- a/src/vim_tests.erl
+++ b/src/vim_tests.erl
@@ -28,23 +28,3 @@ handle_regex_redos_with_backslash_test() ->
 handle_regex_redos_with_space_test() ->
   Result = vim:handle_regex("foo", "f\{ 999,99999}"),
   ?assert(Result =:= {"Your pattern has been rejected. Please email me with your use case.", ""}).
-
-handle_regex_slash_test() ->
-  Result = vim:handle_regex("foo", "f/"),
-  ?assert(Result =:= {"Your pattern has been rejected. Please email me with your use case.", ""}).
-
-handle_regex_slash_start_of_line_test() ->
-  Result = vim:handle_regex("foo", "/f"),
-  ?assert(Result =:= {"Your pattern has been rejected. Please email me with your use case.", ""}).
-
-handle_regex_odd_slash_test() ->
-  ResultOne = vim:handle_regex("f/oo", "f\\/"),
-  ResultThree = vim:handle_regex("f/oo", "f\\\\\\/"),
-  ?assert(ResultOne =/= {"Your pattern has been rejected. Please email me with your use case.", ""}),
-  ?assert(ResultThree =/= {"Your pattern has been rejected. Please email me with your use case.", ""}).
-
-handle_regex_even_escaped_slash_test() ->
-  ResultTwo = vim:handle_regex("f/oo", "f\\\\/"),
-  ResultFour = vim:handle_regex("f/oo", "f\\\\\\\\/"),
-  ?assert(ResultTwo =:= {"Your pattern has been rejected. Please email me with your use case.", ""}),
-  ?assert(ResultFour =:= {"Your pattern has been rejected. Please email me with your use case.", ""}).


### PR DESCRIPTION
since vim does allow unescaped forward slashes in :s commands (as long as you change the delimiter) i figured virex should support them too.
